### PR TITLE
Marking Topics as Resolved and Filtering Resolved Topics

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1,0 +1,41 @@
+## New features
+
+### Feature 1: Mark Post as Answered
+
+The first feature is to mark post as answered. Inside a topic, we add a button "Mark as Answer" for each post. Once the button is clicked, the post is updated to be an answer to the topic. Visually, the whole post field will become light green and the button will turn into "Unmark as answer". If this button is clicked on again, the post will stop to be an answer. Visually, the post will return to the normal style and the button will turn back into "Mark as Answer".
+
+The status of a post being an answer or not is updated in the database, so it will persist upon refreshing the page or restarting the server.
+
+To user test this functionality, try to click on the "Mark/Unmark as Answer" button for several different posts and refresh the page or restart the server to check if the changes persist.
+
+### Feature 2: Filter Answered Posts
+
+We add a button at the top of each topic called "Show Answers Only". When a user clicks this button, only posts that were marked as answers will appear. If the user wants to show all posts again, just refresh the page and all posts will come back.
+
+If a user changes a post from answer to not an answer when showing answers only, the post will not disappear immediately in order to give the user feedback of the operation (the post is indeed marked as not an answer). The post will only disapper if the user clicks "Show Answer Only" again.
+
+To user test this functionality, mark a few posts as answers and click "Show Answers Only". Then, try to unmark a few posts as answers and click on the button again. Refresh the page anytime to see all posts.
+
+### Feature 3: Mark Topic as Resolved
+
+We add a button at the top of each topic to mark a topic as resolved. There are visual clues for the effect of clicking this button, including a green check next to the topic title and the legend on the button.
+
+To user test this functionality, click on the button and see the visual clues.
+
+### Feature 3: Filter Resolved Topics
+
+Inside each category, users can filter resolved topics by clicking the button "Show Resolved Only" at the top right row of the category page. Users can get back all topics by refreshing the page. Besides, we also put a visual clue for resolved topic: a green check next to the title.
+
+To user test this functionality, mark a few topics as resolved and see the visual clues in the category page. Click on the button to filter resolved topics only and refresh the page to see all topics.
+
+## Testing
+
+We add automated tests in the following files:
+
+ * test/controllers.js
+ * test/posts.js
+ * test/topics.js
+
+The code in posts.js and topics.js tests the two new functions we added to update a post as (not) an answer and update a topic as (not) resolved. When testing the controllers, we decided to use the lean controller testing methodology. This means that we tested that the controllers return the expected response only. The controller tests helps make sure that our new endpoints are working correctly.
+
+We made slight changes in the GET method handlers of the topic and category controllers to help frontend achieve more responsive visual effects. We test these changes by confirming the visual effects in the frontend is the same as expected.

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -22,7 +22,7 @@ We add a button at the top of each topic to mark a topic as resolved. There are 
 
 To user test this functionality, click on the button and see the visual clues.
 
-### Feature 3: Filter Resolved Topics
+### Feature 4: Filter Resolved Topics
 
 Inside each category, users can filter resolved topics by clicking the button "Show Resolved Only" at the top right row of the category page. Users can get back all topics by refreshing the page. Besides, we also put a visual clue for resolved topic: a green check next to the title.
 

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -142,6 +142,8 @@ paths:
     $ref: 'write/posts/pid/bookmark.yaml'
   /posts/{pid}/mark-as-answer:
     $ref: 'write/posts/pid/markasanswer.yaml'
+  /topics/{tid}/toggle-resolved:
+    $ref: 'write/topics/tid/toggleresolved.yaml'
   /posts/{pid}/diffs:
     $ref: 'write/posts/pid/diffs.yaml'
   /posts/{pid}/diffs/{since}:

--- a/public/openapi/write/topics/tid/toggleresolved.yaml
+++ b/public/openapi/write/topics/tid/toggleresolved.yaml
@@ -1,0 +1,26 @@
+get:
+  tags:
+    - topic
+  summary: toggle a topic as resolved or unresolved
+  description: This operation marks a topic as resolved.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 2
+  responses:
+    '200':
+      description: Topic successfully marked as resolved
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}

--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -97,10 +97,10 @@ categoryController.get = async function (req, res, next) {
     categoryData.topics.forEach((topic) => {
         topic.resolved = (topic.resolved === 'true');
         topic.resolved_tag = topic.resolved ? 'true' : 'false';
-        console.log("THIS IS A TEST!!!")
-        console.log(topic.resolved === true)
+        console.log('THIS IS A TEST!!!');
+        console.log(topic.resolved === true);
     });
-    console.log(categoryData.topics)
+    console.log(categoryData.topics);
 
     categories.modifyTopicsByPrivilege(categoryData.topics, userPrivileges);
     categoryData.tagWhitelist = categories.filterTagWhitelist(categoryData.tagWhitelist, userPrivileges.isAdminOrMod);

--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -94,6 +94,14 @@ categoryController.get = async function (req, res, next) {
         return next();
     }
 
+    categoryData.topics.forEach((topic) => {
+        topic.resolved = (topic.resolved === 'true');
+        topic.resolved_tag = topic.resolved ? 'true' : 'false';
+        console.log("THIS IS A TEST!!!")
+        console.log(topic.resolved === true)
+    });
+    console.log(categoryData.topics)
+
     categories.modifyTopicsByPrivilege(categoryData.topics, userPrivileges);
     categoryData.tagWhitelist = categories.filterTagWhitelist(categoryData.tagWhitelist, userPrivileges.isAdminOrMod);
 

--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -97,8 +97,6 @@ categoryController.get = async function (req, res, next) {
     categoryData.topics.forEach((topic) => {
         topic.resolved = (topic.resolved === 'true');
         topic.resolved_tag = topic.resolved ? 'true' : 'false';
-        console.log('THIS IS A TEST!!!');
-        console.log(topic.resolved === true);
     });
     console.log(categoryData.topics);
 

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -83,6 +83,7 @@ topicsController.get = async function getTopic(req, res, next) {
         post.is_answer = (post.is_answer === 'true');
         post.is_answer_tag = post.is_answer ? 'true' : 'false';
     });
+    topicData.resolved = (topicData.resolved === 'true');
 
     topics.modifyPostsByPrivilege(topicData, userPrivileges);
     topicData.tagWhitelist = categories.filterTagWhitelist(topicData.tagWhitelist, userPrivileges.isAdminOrMod);

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -41,6 +41,10 @@ Topics.reply = async (req, res) => {
     }
 };
 
+Topics.markAsResolved = async (req, res) => {
+    await topics.markAsResolved(req.params.tid);
+    helpers.formatApiResponse(200, res);
+};
 async function lockPosting(req, error) {
     const id = req.uid > 0 ? req.uid : req.sessionID;
     const value = `posting${id}`;

--- a/src/posts/create.ts
+++ b/src/posts/create.ts
@@ -21,6 +21,8 @@ export type PostObject = {
     ip?: number;
     handle?: number;
     cid?: number;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     uploads?: any;
   };
 

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -18,6 +18,8 @@ module.exports = function () {
     setupApiRoute(router, 'post', '/:tid', [middleware.checkRequired.bind(null, ['content']), middleware.assert.topic], controllers.write.topics.reply);
     setupApiRoute(router, 'delete', '/:tid', [...middlewares], controllers.write.topics.purge);
 
+    setupApiRoute(router, 'get', '/:tid', [], controllers.write.topics.markAsResolved);
+
     setupApiRoute(router, 'put', '/:tid/state', [...middlewares], controllers.write.topics.restore);
     setupApiRoute(router, 'delete', '/:tid/state', [...middlewares], controllers.write.topics.delete);
 

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -18,7 +18,7 @@ module.exports = function () {
     setupApiRoute(router, 'post', '/:tid', [middleware.checkRequired.bind(null, ['content']), middleware.assert.topic], controllers.write.topics.reply);
     setupApiRoute(router, 'delete', '/:tid', [...middlewares], controllers.write.topics.purge);
 
-    setupApiRoute(router, 'get', '/:tid', [], controllers.write.topics.markAsResolved);
+    setupApiRoute(router, 'get', '/:tid/toggle-resolved', [], controllers.write.topics.markAsResolved);
 
     setupApiRoute(router, 'put', '/:tid/state', [...middlewares], controllers.write.topics.restore);
     setupApiRoute(router, 'delete', '/:tid/state', [...middlewares], controllers.write.topics.delete);

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -1,6 +1,7 @@
-'use strict';
+"use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const express = require("express");
+const multipart = require("connect-multiparty");
 const middleware = require("../../middleware");
 const controllers = require("../../controllers");
 const routeHelpers = require("../helpers");
@@ -8,7 +9,7 @@ const router = express.Router();
 const { setupApiRoute } = routeHelpers;
 module.exports = function () {
     const middlewares = [middleware.ensureLoggedIn];
-    const multipart = require('connect-multiparty');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
     const multipartMiddleware = multipart();
     setupApiRoute(router, 'post', '/', [middleware.checkRequired.bind(null, ['cid', 'title', 'content'])], controllers.write.topics.create);
     setupApiRoute(router, 'get', '/:tid', [], controllers.write.topics.get);

--- a/src/routes/write/topics.ts
+++ b/src/routes/write/topics.ts
@@ -1,38 +1,51 @@
 'use strict';
-Object.defineProperty(exports, "__esModule", { value: true });
-const express = require("express");
-const middleware = require("../../middleware");
-const controllers = require("../../controllers");
-const routeHelpers = require("../helpers");
+
+import express = require('express');
+import middleware = require('../../middleware');
+import controllers = require('../../controllers');
+import routeHelpers = require('../helpers');
+
 const router = express.Router();
 const { setupApiRoute } = routeHelpers;
+
 module.exports = function () {
     const middlewares = [middleware.ensureLoggedIn];
+
     const multipart = require('connect-multiparty');
     const multipartMiddleware = multipart();
+
     setupApiRoute(router, 'post', '/', [middleware.checkRequired.bind(null, ['cid', 'title', 'content'])], controllers.write.topics.create);
     setupApiRoute(router, 'get', '/:tid', [], controllers.write.topics.get);
     setupApiRoute(router, 'post', '/:tid', [middleware.checkRequired.bind(null, ['content']), middleware.assert.topic], controllers.write.topics.reply);
     setupApiRoute(router, 'delete', '/:tid', [...middlewares], controllers.write.topics.purge);
+
     setupApiRoute(router, 'get', '/:tid/toggle-resolved', [], controllers.write.topics.markAsResolved);
+
     setupApiRoute(router, 'put', '/:tid/state', [...middlewares], controllers.write.topics.restore);
     setupApiRoute(router, 'delete', '/:tid/state', [...middlewares], controllers.write.topics.delete);
+
     setupApiRoute(router, 'put', '/:tid/pin', [...middlewares, middleware.assert.topic], controllers.write.topics.pin);
     setupApiRoute(router, 'delete', '/:tid/pin', [...middlewares], controllers.write.topics.unpin);
+
     setupApiRoute(router, 'put', '/:tid/lock', [...middlewares], controllers.write.topics.lock);
     setupApiRoute(router, 'delete', '/:tid/lock', [...middlewares], controllers.write.topics.unlock);
+
     setupApiRoute(router, 'put', '/:tid/follow', [...middlewares, middleware.assert.topic], controllers.write.topics.follow);
     setupApiRoute(router, 'delete', '/:tid/follow', [...middlewares, middleware.assert.topic], controllers.write.topics.unfollow);
     setupApiRoute(router, 'put', '/:tid/ignore', [...middlewares, middleware.assert.topic], controllers.write.topics.ignore);
     setupApiRoute(router, 'delete', '/:tid/ignore', [...middlewares, middleware.assert.topic], controllers.write.topics.unfollow); // intentional, unignore == unfollow
+
     setupApiRoute(router, 'put', '/:tid/tags', [...middlewares, middleware.checkRequired.bind(null, ['tags']), middleware.assert.topic], controllers.write.topics.addTags);
     setupApiRoute(router, 'delete', '/:tid/tags', [...middlewares, middleware.assert.topic], controllers.write.topics.deleteTags);
+
     setupApiRoute(router, 'get', '/:tid/thumbs', [], controllers.write.topics.getThumbs);
     setupApiRoute(router, 'post', '/:tid/thumbs', [multipartMiddleware, middleware.validateFiles, middleware.uploads.ratelimit, ...middlewares], controllers.write.topics.addThumb);
     setupApiRoute(router, 'put', '/:tid/thumbs', [...middlewares, middleware.checkRequired.bind(null, ['tid'])], controllers.write.topics.migrateThumbs);
     setupApiRoute(router, 'delete', '/:tid/thumbs', [...middlewares, middleware.checkRequired.bind(null, ['path'])], controllers.write.topics.deleteThumb);
     setupApiRoute(router, 'put', '/:tid/thumbs/order', [...middlewares, middleware.checkRequired.bind(null, ['path', 'order'])], controllers.write.topics.reorderThumbs);
+
     setupApiRoute(router, 'get', '/:tid/events', [middleware.assert.topic], controllers.write.topics.getEvents);
     setupApiRoute(router, 'delete', '/:tid/events/:eventId', [middleware.assert.topic], controllers.write.topics.deleteEvent);
+
     return router;
 };

--- a/src/routes/write/topics.ts
+++ b/src/routes/write/topics.ts
@@ -1,6 +1,5 @@
-'use strict';
-
 import express = require('express');
+import multipart = require('connect-multiparty');
 import middleware = require('../../middleware');
 import controllers = require('../../controllers');
 import routeHelpers = require('../helpers');
@@ -10,8 +9,7 @@ const { setupApiRoute } = routeHelpers;
 
 module.exports = function () {
     const middlewares = [middleware.ensureLoggedIn];
-
-    const multipart = require('connect-multiparty');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
     const multipartMiddleware = multipart();
 
     setupApiRoute(router, 'post', '/', [middleware.checkRequired.bind(null, ['cid', 'title', 'content'])], controllers.write.topics.create);

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -34,6 +34,7 @@ Topics.thumbs = require('./thumbs');
 require('./bookmarks')(Topics);
 require('./merge')(Topics);
 Topics.events = require('./events');
+require('./resolved')(Topics);
 
 Topics.exists = async function (tids) {
     return await db.exists(

--- a/src/topics/resolved.js
+++ b/src/topics/resolved.js
@@ -1,0 +1,36 @@
+"use strict";
+const { topic } = require("../middleware/assert");
+// var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+//     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+//     return new (P || (P = Promise))(function (resolve, reject) {
+//         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+//         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+//         function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+//         step((generator = generator.apply(thisArg, _arguments || [])).next());
+//     });
+// };
+// Object.defineProperty(exports, "__esModule", { value: true });
+const topics = require("../topics");
+module.exports = function (Topics) {
+    Topics.markAsResolved = function (tid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const resolved = yield topics.getTopicField(tid, ['resolved']);
+            if (resolved !== 'true') {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                yield topics.setTopicField(tid, 'resolved', 'true');
+                console.log("*************************************************")
+                console.log(topics.getTopicField(tid, 'resolved'))
+            }
+            else {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                yield topics.setTopicField(tid, 'resolved', 'false');
+                console.log("*************************************************")
+                console.log(topics.getTopicField(tid, 'resolved'))
+            }
+        });
+    };
+};

--- a/src/topics/resolved.js
+++ b/src/topics/resolved.js
@@ -1,24 +1,31 @@
-'use strict';
-
-const topics = require('.');
-
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const topics = require("../topics");
 module.exports = function (Topics) {
-    Topics.markAsResolved = async function (tid) {
-        try {
-            const resolved = await topics.getTopicField(tid, ['resolved']);
-            console.log(resolved, 'before:topicdata');
-            if (resolved !== 'true') {
-                await topics.setTopicField(tid, 'resolved', 'true');
-                console.log('*************************************************Resolved');
-            } else {
-                await topics.setTopicField(tid, 'resolved', 'false');
-                console.log('*************************************************Unresolved');
+    Topics.markAsResolved = function (tid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const is_resolved = yield topics.getTopicField(tid, ['is_resolved']);
+            if (is_resolved !== 'true') {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                yield topics.setTopicField(tid, 'is_resolved', 'true');
             }
-            const topic = await topics.getTopicFields(tid, ['resolved']);
-            console.log(topic, 'after:topicdata');
-            return topic;
-        } catch (err) {
-            console.log(err);
-        }
+            else {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                yield topics.setTopicField(tid, 'is_resolved', 'false');
+            }
+        });
     };
 };

--- a/src/topics/resolved.js
+++ b/src/topics/resolved.js
@@ -1,23 +1,24 @@
 'use strict';
-const topics = require('../topics');
+
+const topics = require('.');
+
 module.exports = function (Topics) {
-    Topics.markAsResolved= async function (tid) {
-        try{
+    Topics.markAsResolved = async function (tid) {
+        try {
             const resolved = await topics.getTopicField(tid, ['resolved']);
             console.log(resolved, 'before:topicdata');
-            if (resolved !== 'true'){
+            if (resolved !== 'true') {
                 await topics.setTopicField(tid, 'resolved', 'true');
-                console.log("*************************************************Resolved")
-            }else{
+                console.log('*************************************************Resolved');
+            } else {
                 await topics.setTopicField(tid, 'resolved', 'false');
-                console.log("*************************************************Unresolved")
+                console.log('*************************************************Unresolved');
             }
             const topic = await topics.getTopicFields(tid, ['resolved']);
             console.log(topic, 'after:topicdata');
             return topic;
-        }
-        catch(err){
+        } catch (err) {
             console.log(err);
         }
-    }
-}
+    };
+};

--- a/src/topics/resolved.js
+++ b/src/topics/resolved.js
@@ -1,36 +1,23 @@
-"use strict";
-const { topic } = require("../middleware/assert");
-// var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-//     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-//     return new (P || (P = Promise))(function (resolve, reject) {
-//         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-//         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-//         function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-//         step((generator = generator.apply(thisArg, _arguments || [])).next());
-//     });
-// };
-// Object.defineProperty(exports, "__esModule", { value: true });
-const topics = require("../topics");
+'use strict';
+const topics = require('../topics');
 module.exports = function (Topics) {
-    Topics.markAsResolved = function (tid) {
-        return __awaiter(this, void 0, void 0, function* () {
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            const resolved = yield topics.getTopicField(tid, ['resolved']);
-            if (resolved !== 'true') {
-                // The next line calls a function in a module that has not been updated to TS yet
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                yield topics.setTopicField(tid, 'resolved', 'true');
-                console.log("*************************************************")
-                console.log(topics.getTopicField(tid, 'resolved'))
+    Topics.markAsResolved= async function (tid) {
+        try{
+            const resolved = await topics.getTopicField(tid, ['resolved']);
+            console.log(resolved, 'before:topicdata');
+            if (resolved !== 'true'){
+                await topics.setTopicField(tid, 'resolved', 'true');
+                console.log("*************************************************Resolved")
+            }else{
+                await topics.setTopicField(tid, 'resolved', 'false');
+                console.log("*************************************************Unresolved")
             }
-            else {
-                // The next line calls a function in a module that has not been updated to TS yet
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                yield topics.setTopicField(tid, 'resolved', 'false');
-                console.log("*************************************************")
-                console.log(topics.getTopicField(tid, 'resolved'))
-            }
-        });
-    };
-};
+            const topic = await topics.getTopicFields(tid, ['resolved']);
+            console.log(topic, 'after:topicdata');
+            return topic;
+        }
+        catch(err){
+            console.log(err);
+        }
+    }
+}

--- a/src/topics/resolved.js
+++ b/src/topics/resolved.js
@@ -15,16 +15,16 @@ module.exports = function (Topics) {
         return __awaiter(this, void 0, void 0, function* () {
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            const is_resolved = yield topics.getTopicField(tid, ['is_resolved']);
-            if (is_resolved !== 'true') {
+            const resolved = yield topics.getTopicField(tid, ['resolved']);
+            if (resolved !== 'true') {
                 // The next line calls a function in a module that has not been updated to TS yet
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                yield topics.setTopicField(tid, 'is_resolved', 'true');
+                yield topics.setTopicField(tid, 'resolved', 'true');
             }
             else {
                 // The next line calls a function in a module that has not been updated to TS yet
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                yield topics.setTopicField(tid, 'is_resolved', 'false');
+                yield topics.setTopicField(tid, 'resolved', 'false');
             }
         });
     };

--- a/src/topics/resolved.ts
+++ b/src/topics/resolved.ts
@@ -1,0 +1,23 @@
+import topics = require('../topics');
+
+export type TopicObject = {
+    tid: number;
+    markAsResolved: (tid:number) => Promise<void>
+};
+
+module.exports = function (Topics:TopicObject) {
+    Topics.markAsResolved = async function (tid:number) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const resolved:string = await topics.getTopicField(tid, ['resolved']) as string;
+        if (resolved !== 'true') {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            await topics.setTopicField(tid, 'resolved', 'true');
+        } else {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            await topics.setTopicField(tid, 'resolved', 'false');
+        }
+    };
+};

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -994,8 +994,26 @@ describe('Controllers', () => {
         });
     });
 
+    it('should get answered posts', (done) => {
+        request(`${nconf.get('url')}/api/v3/posts/${pid}/mark-as-answer`, (err, res, body) => {
+            assert.ifError(err);
+            assert.equal(res.statusCode, 200);
+            assert(body);
+            done();
+        });
+    });
+
     it('should get topic data', (done) => {
         request(`${nconf.get('url')}/api/v3/topics/${tid}`, (err, res, body) => {
+            assert.ifError(err);
+            assert.equal(res.statusCode, 200);
+            assert(body);
+            done();
+        });
+    });
+
+    it('should get topic data', (done) => {
+        request(`${nconf.get('url')}/api/v3/topics/${tid}/toggle-resolved`, (err, res, body) => {
             assert.ifError(err);
             assert.equal(res.statusCode, 200);
             assert(body);
@@ -1199,7 +1217,6 @@ describe('Controllers', () => {
             });
         });
     });
-
 
     describe('maintenance mode', () => {
         before((done) => {

--- a/test/posts.js
+++ b/test/posts.js
@@ -302,6 +302,20 @@ describe('Post\'s', () => {
         });
     });
 
+    describe('marking answers', () => {
+        it('should mark a post as answer', async () => {
+            await posts.markAsAnswer(postData.pid);
+            const is_answer = await posts.getPostField(postData.pid, ['is_answer']);
+            assert.equal(is_answer, 'true');
+        });
+
+        it('should unmark a post as answer', async () => {
+            await posts.markAsAnswer(postData.pid);
+            const is_answer = await posts.getPostField(postData.pid, ['is_answer']);
+            assert.equal(is_answer, 'false');
+        });
+    });
+
     describe('post tools', () => {
         it('should error if data is invalid', (done) => {
             socketPosts.loadPostTools({ uid: globalModUid }, null, (err) => {

--- a/test/topics.js
+++ b/test/topics.js
@@ -2862,20 +2862,19 @@ describe('Topic\'s', () => {
 
         it('should set a topic to resolved', async () => {
             topicData = (await topics.post(topic)).topicData;
-            await topics.markAsResolved(topicData.tid)
+            await topics.markAsResolved(topicData.tid);
             const resolved = await topics.getTopicField(topicData.tid, ['resolved']);
-            assert.equal(resolved, 'true')
+            assert.equal(resolved, 'true');
         });
 
         it('should set a resolved topic to unresolved', async () => {
             topicData = (await topics.post(topic)).topicData;
-            await topics.markAsResolved(topicData.tid)
-            await topics.markAsResolved(topicData.tid)
+            await topics.markAsResolved(topicData.tid);
+            await topics.markAsResolved(topicData.tid);
             const resolved = await topics.getTopicField(topicData.tid, ['resolved']);
-            assert.equal(resolved, 'false')
+            assert.equal(resolved, 'false');
         });
     });
-
 });
 
 describe('Topics\'', async () => {

--- a/test/topics.js
+++ b/test/topics.js
@@ -2831,6 +2831,34 @@ describe('Topic\'s', () => {
             const score = await db.sortedSetScore('topics:scheduled', topicData.tid);
             assert(!score);
         });
+    });
+
+    describe('resolved topics', () => {
+        let categoryObj;
+        let topicData;
+        let topic;
+        let adminApiOpts;
+
+        before(async () => {
+            adminApiOpts = {
+                json: true,
+                jar: adminJar,
+                headers: {
+                    'x-csrf-token': csrf_token,
+                },
+            };
+            categoryObj = await categories.create({
+                name: 'Another Test Category',
+                description: 'Another test category created by testing script',
+            });
+            topic = {
+                uid: adminUid,
+                cid: categoryObj.cid,
+                title: 'Resolved Topics Test Topic Title',
+                content: 'The content of test topic to be resolved',
+                timestamp: new Date(Date.now() + 86400000).getTime(),
+            };
+        });
 
         it('should set a topic to resolved', async () => {
             topicData = (await topics.post(topic)).topicData;
@@ -2847,6 +2875,7 @@ describe('Topic\'s', () => {
             assert.equal(resolved, 'false')
         });
     });
+
 });
 
 describe('Topics\'', async () => {

--- a/test/topics.js
+++ b/test/topics.js
@@ -54,6 +54,8 @@ describe('Topic\'s', () => {
             categoryId: categoryObj.cid,
             title: 'Test Topic Title',
             content: 'The content of test topic',
+            // tid: 1,
+            // resolved: 'false',
         };
     });
 
@@ -2828,6 +2830,21 @@ describe('Topic\'s', () => {
         it('should remove from topics:scheduled on purge', async () => {
             const score = await db.sortedSetScore('topics:scheduled', topicData.tid);
             assert(!score);
+        });
+
+        it('should set a topic to resolved', async () => {
+            topicData = (await topics.post(topic)).topicData;
+            await topics.markAsResolved(topicData.tid)
+            const resolved = await topics.getTopicField(topicData.tid, ['resolved']);
+            assert.equal(resolved, 'true')
+        });
+
+        it('should set a resolved topic to unresolved', async () => {
+            topicData = (await topics.post(topic)).topicData;
+            await topics.markAsResolved(topicData.tid)
+            await topics.markAsResolved(topicData.tid)
+            const resolved = await topics.getTopicField(topicData.tid, ['resolved']);
+            assert.equal(resolved, 'false')
         });
     });
 });

--- a/themes/nodebb-theme-persona/templates/category.tpl
+++ b/themes/nodebb-theme-persona/templates/category.tpl
@@ -25,6 +25,26 @@
                 <!-- IMPORT partials/category/watch.tpl -->
                 <!-- IMPORT partials/category/sort.tpl -->
                 <!-- IMPORT partials/category/tools.tpl -->
+                <div class="btn-group bottom-sheet" component="thread/sort">
+                    <script>
+                        function toggleShowResolved() {
+                            var elems = document.getElementsByClassName('topic-tag');
+                            let i = 0;
+                            while(i < elems.length) {
+                                if(elems[i].getAttribute('data-is-resolved') === 'true') {
+                                    i++;
+                                }
+                                else {
+                                    elems[i].remove();
+                                }
+                            }
+                        }
+                    </script>
+                    <button onclick="toggleShowResolved()" class="btn btn-primary" type="button">
+                        <span class="visible-sm-inline visible-md-inline visible-lg-inline">Show Resolved Only</span>
+                        <span class="visible-xs-inline"><i class="fa fa-fw fa-sort"></i></span>
+                    </button>
+                </div>
             </span>
         </div>
 

--- a/themes/nodebb-theme-persona/templates/partials/post_bar.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/post_bar.tpl
@@ -17,4 +17,40 @@
     <!-- IMPORT partials/thread_tools.tpl -->
     </div>
     <!-- IMPORT partials/topic/reply-button.tpl -->
+    
+    <script>
+        function toggleShowAnswer(tid) {
+            var elems = document.getElementsByClassName('post-tag');
+            let i = 0;
+            while(i < elems.length) {
+                if(elems[i].getAttribute('data-is-answer') === 'true') {
+                    i++;
+                }
+                else {
+                    elems[i].remove();
+                }
+            }
+        }
+        function toggleResolved(tid) {
+            fetch("/api/v3/topics/"+tid+"/toggle-resolved");
+            var id = "toggle-resolved-"+tid;
+            if(document.getElementById(id).innerHTML.includes('Unmark')) {
+                document.getElementById("check-"+tid).style.display = "none";
+                document.getElementById(id).innerHTML = '<b>Mark as Resolved</b>';
+            }
+            else {
+                document.getElementById("check-"+tid).style.display = "inline";
+                document.getElementById(id).innerHTML = '<b>Unmark as Resolved</b>';
+            }
+        }
+    </script>
+
+    <button onclick="toggleShowAnswer({tid})" id="toggle-show-answer-{tid}" class="btn btn-primary btn-sm">
+        <b>Show Answers Only</b>
+    </button>
+
+    <button onclick="toggleResolved({tid})" id="toggle-resolved-{tid}" class="btn btn-primary btn-sm">
+        {{{if resolved}}}<b>Unmark as Resolved</b>{{{else}}}<b>Mark as Resolved</b>{{{end}}}
+    </button>
+
 </div>

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -125,7 +125,7 @@
                 }
             }
         </script>  
-        <button onclick="toggleAnswer({posts.pid})" id="toggle-answer-{posts.pid}" class="btn btn-primary">
+        <button onclick="toggleAnswer({posts.pid})" id="toggle-answer-{posts.pid}" class="btn btn-primary btn-sm">
             {{{ if posts.is_answer }}} Unmark as Answer {{{ end }}}
             {{{ if !posts.is_answer }}} Mark as Answer {{{ end }}}
         </button>

--- a/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
@@ -1,6 +1,6 @@
 <ul component="category" class="topic-list" itemscope itemtype="http://www.schema.org/ItemList" data-nextstart="{nextStart}" data-set="{set}">
     {{{each topics}}}
-    <li component="category/topic" class="row clearfix category-item {function.generateTopicClass}" <!-- IMPORT partials/data/category.tpl -->>
+    <li component="category/topic" class="topic-tag row clearfix category-item {function.generateTopicClass}" <!-- IMPORT partials/data/category.tpl --> data-is-resolved="{topics.resolved_tag}">
         <link itemprop="url" content="{config.relative_path}/topic/{../slug}" />
         <meta itemprop="name" content="{function.stripTags, ../title}" />
         <meta itemprop="itemListOrder" content="descending" />
@@ -40,10 +40,14 @@
 
 
                 <!-- IF !topics.noAnchor -->
-                <a href="{config.relative_path}/topic/{topics.slug}<!-- IF topics.bookmark -->/{topics.bookmark}<!-- ENDIF topics.bookmark -->">{topics.title}</a><br />
+                <a href="{config.relative_path}/topic/{topics.slug}<!-- IF topics.bookmark -->/{topics.bookmark}<!-- ENDIF topics.bookmark -->">{topics.title}</a>
                 <!-- ELSE -->
-                <span>{topics.title}</span><br />
+                <span>{topics.title}</span>
                 <!-- ENDIF !topics.noAnchor -->
+                <small id="list-check-{tid}" style="display: {{{ if topics.resolved }}}inline{{{ else }}}none{{{ end }}}; font-size: 15px;">
+                    ✅
+                </small>
+                <br />
 
                 <!-- IF !template.category -->
                 <small>

--- a/themes/nodebb-theme-persona/templates/topic.tpl
+++ b/themes/nodebb-theme-persona/templates/topic.tpl
@@ -17,6 +17,9 @@
                     </span>
                     <span component="topic/title">{title}</span>
                 </span>
+                <small id="check-{tid}" style="display: {{{ if resolved }}}inline{{{ else }}}none{{{ end }}}; font-size: 15px;">
+                    Resolved ✅
+                </small>
             </h1>
 
             <div class="topic-info clearfix">
@@ -43,24 +46,8 @@
                 {{{ end }}}
 
                 <!-- IMPORT partials/post_bar.tpl -->
+
             </div>  
-            <script>
-                function toggleShowAnswer(tid) {
-                    var elems = document.getElementsByClassName('post-tag');
-                    let i = 0;
-                    while(i < elems.length) {
-                        if(elems[i].getAttribute('data-is-answer') === 'true') {
-                            i++;
-                        }
-                        else {
-                            elems[i].remove();
-                        }
-                    }
-                }
-            </script>  
-            <button onclick="toggleShowAnswer({tid})" id="toggle-show-answer-{tid}" class="btn btn-primary">
-                <b>Show Answers Only</b>
-            </button>
         </div>
         <!-- IF merger -->
         <div component="topic/merged/message" class="alert alert-warning clearfix">


### PR DESCRIPTION
We added the following two features during Sprint 2. 

1. Marking topics as _resolved_
2. Filtering resolved topics

resolves #13
resolves #14
resolves #15
resolves #16

**Testing**
We added unit testing for the functions we added to implement our functionality. Additionally, we tested that our controllers return the expected server responses.

**Documentation**
We added documentation for all of our changes during Sprint 1 and Sprint 2. It can be found in the UserGuide.md file the root directory.